### PR TITLE
Fix parse float csv to json

### DIFF
--- a/filebeat_data_shipper_test/README.md
+++ b/filebeat_data_shipper_test/README.md
@@ -19,3 +19,34 @@ robot tracking_response_time-day2-config.robot
 # 5. Execute the Robot Framework script related to the experiment execution.
 robot execute_script.robot
 ```
+
+## Metric Data Model
+
+- `metric_value` is a float or integer value
+- `timestamp` is a 10-digit float or integer value (unix epoch)
+- `unit` is any string representing the unit of the measurement
+- `device_id` is any string identifying the device generating the metric
+- `context` contains the context parameters (empty here)
+
+### CSV example
+
+```
+metric_value,timestamp,unit,device_id,context
+5.47,1602349170.00,%,localhost.localdomain,
+```
+
+### JSON example
+
+```json
+records: [
+  {
+    "value": {
+      "context": {},
+      "metric_value": 34.52,
+      "timestamp": 1602348105.56,
+      "unit": "%",
+      "device_id": "localhost.localdomain"
+    }
+  }
+]
+```

--- a/filebeat_data_shipper_test/ansible/filebeat.yml
+++ b/filebeat_data_shipper_test/ansible/filebeat.yml
@@ -21,6 +21,8 @@ processors:
               result[json_fields[index]] = field;
               return result;
             }, {})
+            json_from_csv["metric_value"] = parseFloat(json_from_csv["metric_value"])
+            json_from_csv["timestamp"] = parseFloat(json_from_csv["timestamp"])
             var value = {
               value: json_from_csv
             };

--- a/install_filebeat/ansible/filebeat.yml
+++ b/install_filebeat/ansible/filebeat.yml
@@ -21,6 +21,8 @@ processors:
               result[json_fields[index]] = field;
               return result;
             }, {})
+            json_from_csv["metric_value"] = parseFloat(json_from_csv["metric_value"])
+            json_from_csv["timestamp"] = parseFloat(json_from_csv["timestamp"])
             var value = {
               value: json_from_csv
             };

--- a/python_data_shipper_test/README.md
+++ b/python_data_shipper_test/README.md
@@ -17,3 +17,35 @@ robot day2-config.robot
 
 # 5. Execute the Robot Framework script related to the experiment execution.
 robot execute_script.robot
+```
+
+## Metric Data Model
+
+- `metric_value` is a float or integer value
+- `timestamp` is a 10-digit float or integer value (unix epoch)
+- `unit` is any string representing the unit of the measurement
+- `device_id` is any string identifying the device generating the metric
+- `context` contains the context parameters (empty here)
+
+### CSV example
+
+```
+metric_value,timestamp,unit,device_id,context
+5.47,1602349170.00,%,localhost.localdomain,
+```
+
+### JSON example
+
+```json
+records: [
+  {
+    "value": {
+      "context": {},
+      "metric_value": 34.52,
+      "timestamp": 1602348105.56,
+      "unit": "%",
+      "device_id": "localhost.localdomain"
+    }
+  }
+]
+```

--- a/python_data_shipper_test/ansible/filebeat.yml
+++ b/python_data_shipper_test/ansible/filebeat.yml
@@ -21,6 +21,8 @@ processors:
               result[json_fields[index]] = field;
               return result;
             }, {})
+            json_from_csv["metric_value"] = parseFloat(json_from_csv["metric_value"])
+            json_from_csv["timestamp"] = parseFloat(json_from_csv["timestamp"])
             var value = {
               value: json_from_csv
             };

--- a/spanish_site_demo_20th_may_2020/ansible/filebeat.yml
+++ b/spanish_site_demo_20th_may_2020/ansible/filebeat.yml
@@ -21,6 +21,8 @@ processors:
               result[json_fields[index]] = field;
               return result;
             }, {})
+            json_from_csv["metric_value"] = parseFloat(json_from_csv["metric_value"])
+            json_from_csv["timestamp"] = parseFloat(json_from_csv["timestamp"])
             var value = {
               value: json_from_csv
             };


### PR DESCRIPTION
The `javascript` code in the Filebeat configuration converts all CSV values to JSON strings, even the `timestamp` and the `metric_value`. I added the `parseFloat()` function to convert the mentioned fields to float.

I added a short explanation of the metrics data model and some examples to README files.